### PR TITLE
Adding defined types for all assemblies in a provider

### DIFF
--- a/Source/DotNET/Fundamentals/Types/ICanProvideAssembliesForDiscovery.cs
+++ b/Source/DotNET/Fundamentals/Types/ICanProvideAssembliesForDiscovery.cs
@@ -14,4 +14,9 @@ public interface ICanProvideAssembliesForDiscovery
     /// Gets the assemblies to use for type discovery.
     /// </summary>
     IEnumerable<Assembly> Assemblies { get; }
+
+    /// <summary>
+    /// Gets all the defined types from all the assemblies.
+    /// </summary>
+    IEnumerable<Type> DefinedTypes { get; }
 }

--- a/Source/DotNET/Fundamentals/Types/PackageReferencedAssemblies.cs
+++ b/Source/DotNET/Fundamentals/Types/PackageReferencedAssemblies.cs
@@ -45,6 +45,9 @@ public class PackageReferencedAssemblies : ICanProvideAssembliesForDiscovery
     /// <inheritdoc/>
     public IEnumerable<Assembly> Assemblies => _assemblies;
 
+    /// <inheritdoc/>
+    public IEnumerable<Type> DefinedTypes { get; }
+
     /// <summary>
     /// Initializes a new instance of <see cref="Types"/>.
     /// </summary>
@@ -62,6 +65,7 @@ public class PackageReferencedAssemblies : ICanProvideAssembliesForDiscovery
                             .Distinct()
                             .ToArray();
         _assemblies.AddRange(assemblies);
+        DefinedTypes = _assemblies.SelectMany(_ => _.DefinedTypes);
     }
 
     /// <summary>

--- a/Source/DotNET/Fundamentals/Types/ProjectReferencedAssemblies.cs
+++ b/Source/DotNET/Fundamentals/Types/ProjectReferencedAssemblies.cs
@@ -25,6 +25,9 @@ public class ProjectReferencedAssemblies : ICanProvideAssembliesForDiscovery
     /// <inheritdoc/>
     public IEnumerable<Assembly> Assemblies => _assemblies;
 
+    /// <inheritdoc/>
+    public IEnumerable<Type> DefinedTypes { get; }
+
     /// <summary>
     /// Initializes a new instance of <see cref="ProjectReferencedAssemblies"/>.
     /// </summary>
@@ -39,5 +42,6 @@ public class ProjectReferencedAssemblies : ICanProvideAssembliesForDiscovery
                             .Distinct()
                             .ToArray();
         _assemblies.AddRange(projectReferencedAssemblies);
+        DefinedTypes = _assemblies.SelectMany(_ => _.DefinedTypes);
     }
 }

--- a/Source/DotNET/Fundamentals/Types/Types.cs
+++ b/Source/DotNET/Fundamentals/Types/Types.cs
@@ -42,7 +42,7 @@ public class Types : ITypes
     {
         var assemblies = assemblyProviders.SelectMany(_ => _.Assemblies).Distinct();
         _assemblies.AddRange(assemblies);
-        All = DiscoverAllTypes();
+        All = _assemblies.SelectMany(_ => _.DefinedTypes);
         _contractToImplementorsMap.Feed(All);
     }
 
@@ -86,15 +86,5 @@ public class Types : ITypes
         {
             throw new UnableToResolveTypeByName(fullName);
         }
-    }
-
-    IEnumerable<Type> DiscoverAllTypes()
-    {
-        var types = new List<Type>();
-        foreach (var assembly in _assemblies)
-        {
-            types.AddRange(assembly.DefinedTypes);
-        }
-        return types;
     }
 }


### PR DESCRIPTION
### Added

- Added a `DefinedTypes` property for `ICanProvideAssembliesForDiscovery` and implemented for the different providers.

