### PR TITLE
Exposing a global singleton instance that could be used

### DIFF
--- a/Source/DotNET/Fundamentals/Serialization/DerivedTypes.cs
+++ b/Source/DotNET/Fundamentals/Serialization/DerivedTypes.cs
@@ -16,6 +16,15 @@ public class DerivedTypes : IDerivedTypes
 {
     record DerivedTypeAndIdentifier(Type DerivedType, Type TargetType, DerivedTypeId Identifier);
 
+    /// <summary>
+    /// Gets the global instance of <see cref="DerivedTypes"/>.
+    /// </summary>
+    /// <remarks>
+    /// Its recommended to use the singleton defined here, rather than building your own instance.
+    /// This is due to the performance impact of scanning all assemblies in the application.
+    /// </remarks>
+    public static readonly DerivedTypes Instance = new(Aksio.Types.Types.Instance);
+
     readonly IDictionary<Type, IEnumerable<DerivedTypeAndIdentifier>> _targetTypeToDerivedType;
     readonly IDictionary<Type, Type> _derivedTypeToTargetType;
 

--- a/Source/DotNET/Fundamentals/Types/PackageReferencedAssemblies.cs
+++ b/Source/DotNET/Fundamentals/Types/PackageReferencedAssemblies.cs
@@ -12,7 +12,7 @@ namespace Aksio.Types;
 public class PackageReferencedAssemblies : ICanProvideAssembliesForDiscovery
 {
     /// <summary>
-    /// Gets the instance of <see cref="PackageReferencedAssemblies"/>.
+    /// Gets the global instance of <see cref="PackageReferencedAssemblies"/>.
     /// </summary>
     /// <remarks>
     /// Its recommended to use the singleton defined here, rather than building your own instance.

--- a/Source/DotNET/Fundamentals/Types/ProjectReferencedAssemblies.cs
+++ b/Source/DotNET/Fundamentals/Types/ProjectReferencedAssemblies.cs
@@ -12,7 +12,7 @@ namespace Aksio.Types;
 public class ProjectReferencedAssemblies : ICanProvideAssembliesForDiscovery
 {
     /// <summary>
-    /// Gets the instance of <see cref="PackageReferencedAssemblies"/>.
+    /// Gets the global instance of <see cref="PackageReferencedAssemblies"/>.
     /// </summary>
     /// <remarks>
     /// Its recommended to use the singleton defined here, rather than building your own instance.

--- a/Source/DotNET/Fundamentals/Types/Types.cs
+++ b/Source/DotNET/Fundamentals/Types/Types.cs
@@ -11,6 +11,15 @@ namespace Aksio.Types;
 /// </summary>
 public class Types : ITypes
 {
+    /// <summary>
+    /// Gets the global instance of <see cref="Types"/>.
+    /// </summary>
+    /// <remarks>
+    /// Its recommended to use the singleton defined here, rather than building your own instance.
+    /// This is due to the performance impact of scanning all assemblies in the application.
+    /// </remarks>
+    public static readonly Types Instance = new();
+
     readonly IContractToImplementorsMap _contractToImplementorsMap = new ContractToImplementorsMap();
     readonly List<Assembly> _assemblies = new();
 


### PR DESCRIPTION
### Added

- Static global instances of `Types` and `DerivedTypes` which is recommended to be used to avoid initializing multiple of these. It is recommended to register these with your IoC.
