### PR TITLE
Adding explicit support for JsonValue conversion of types

### DIFF
--- a/Source/DotNET/Fundamentals/Types/TypeConversion.cs
+++ b/Source/DotNET/Fundamentals/Types/TypeConversion.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Globalization;
+using System.Reflection;
+using System.Text.Json.Nodes;
 using Aksio.Concepts;
 using Aksio.Reflection;
 
@@ -12,6 +14,8 @@ namespace Aksio.Types;
 /// </summary>
 public static class TypeConversion
 {
+    static readonly MethodInfo _getValueMethod = typeof(JsonValue).GetMethod(nameof(JsonValue.GetValue))!;
+
     /// <summary>
     /// Convert a value to specified type.
     /// </summary>
@@ -23,6 +27,24 @@ public static class TypeConversion
         if (value is null)
         {
             return value!;
+        }
+
+        if (value is JsonValue)
+        {
+            try
+            {
+                return _getValueMethod.MakeGenericMethod(type).Invoke(value, Array.Empty<object>())!;
+            }
+            catch
+            {
+                try
+                {
+                    return System.Convert.ChangeType(value.ToString(), type, CultureInfo.InvariantCulture)!;
+                }
+                catch
+                {
+                }
+            }
         }
 
         var val = new object();

--- a/Specifications/Fundamentals/Types/for_TypeConversion/when_converting_json_double_value_to_double.cs
+++ b/Specifications/Fundamentals/Types/for_TypeConversion/when_converting_json_double_value_to_double.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+
+namespace Aksio.Types.for_TypeConversion;
+
+public class when_converting_json_double_value_to_double : Specification
+{
+    JsonValue input;
+    double result;
+
+    void Establish() => input = JsonValue.Create(42.0);
+
+    void Because() => result = (double)TypeConversion.Convert(typeof(double), input);
+
+    [Fact] void should_convert_correctly() => result.ShouldEqual(42.0);
+}

--- a/Specifications/Fundamentals/Types/for_TypeConversion/when_converting_json_int_value_to_double.cs
+++ b/Specifications/Fundamentals/Types/for_TypeConversion/when_converting_json_int_value_to_double.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json.Nodes;
+
+namespace Aksio.Types.for_TypeConversion;
+
+public class when_converting_json_int_value_to_double : Specification
+{
+    JsonValue input;
+    double result;
+
+    void Establish() => input = JsonValue.Create(42);
+
+    void Because() => result = (double)TypeConversion.Convert(typeof(double), input);
+
+    [Fact] void should_convert_correctly() => result.ShouldEqual(42.0);
+}


### PR DESCRIPTION
### Fixed

- Support for converting directly from `JsonValue` to a target type in `TypeConversion`.
