### PR TITLE
Using by default the global derived types

### DIFF
--- a/Source/DotNET/Fundamentals/Json/Globals.cs
+++ b/Source/DotNET/Fundamentals/Json/Globals.cs
@@ -23,7 +23,7 @@ public static class Globals
         {
             if (_jsonSerializerOptions is null)
             {
-                Configure(null!);
+                Configure(DerivedTypes.Instance);
             }
 
             return _jsonSerializerOptions!;


### PR DESCRIPTION
### Fixed

- Fixed the `Globals.JsonSerializerOptions` property to use the default `DerivedTypes.Instance` when calling `Configure` the first time its used and the `JsonSerializerOptions` hasn't been configured yet. This means that if you want to have a different provider for derived types, you have to make sure you call the `.Configure()` method with your derived types before the options are used by others.
