### PR TITLE
Add entry assembly as the first project referenced assembly

### DIFF
--- a/Source/DotNET/Fundamentals/Types/ProjectReferencedAssemblies.cs
+++ b/Source/DotNET/Fundamentals/Types/ProjectReferencedAssemblies.cs
@@ -35,7 +35,8 @@ public class ProjectReferencedAssemblies : ICanProvideAssembliesForDiscovery
     {
         lock (_lock)
         {
-            var entryAssembly = Assembly.GetEntryAssembly();
+            var entryAssembly = Assembly.GetEntryAssembly()!;
+            _assemblies.Add(entryAssembly);
             var dependencyModel = DependencyContext.Load(entryAssembly);
             var projectReferencedAssemblies = dependencyModel.RuntimeLibraries
                                 .Where(_ => _.Type.Equals("project"))


### PR DESCRIPTION
### Fixed

- Adding the entry assembly as the first "project referenced" assembly in the `ProjectReferencedAssemblies` provider. As this is the assembly used to discover other project referenced assemblies, it is only natural to include itself.
