### PR TITLE
Do ToArray() on expensive LINQ queries that should only happen once

### DIFF
--- a/Source/DotNET/Fundamentals/Types/PackageReferencedAssemblies.cs
+++ b/Source/DotNET/Fundamentals/Types/PackageReferencedAssemblies.cs
@@ -58,7 +58,7 @@ public class PackageReferencedAssemblies : ICanProvideAssembliesForDiscovery
                                 .Distinct()
                                 .ToArray();
             _assemblies.AddRange(assemblies);
-            DefinedTypes = _assemblies.SelectMany(_ => _.DefinedTypes);
+            DefinedTypes = _assemblies.SelectMany(_ => _.DefinedTypes).ToArray();
 
             _initialized = true;
         }

--- a/Source/DotNET/Fundamentals/Types/ProjectReferencedAssemblies.cs
+++ b/Source/DotNET/Fundamentals/Types/ProjectReferencedAssemblies.cs
@@ -45,7 +45,7 @@ public class ProjectReferencedAssemblies : ICanProvideAssembliesForDiscovery
                                 .Distinct()
                                 .ToArray();
             _assemblies.AddRange(projectReferencedAssemblies);
-            DefinedTypes = _assemblies.SelectMany(_ => _.DefinedTypes);
+            DefinedTypes = _assemblies.SelectMany(_ => _.DefinedTypes).ToArray();
         }
     }
 }

--- a/Source/DotNET/Fundamentals/Types/Types.cs
+++ b/Source/DotNET/Fundamentals/Types/Types.cs
@@ -53,7 +53,7 @@ public class Types : ITypes
         assemblyProviders.ForEach(_ => _.Initialize());
         var assemblies = assemblyProviders.SelectMany(_ => _.Assemblies).Distinct();
         _assemblies.AddRange(assemblies);
-        All = _assemblies.SelectMany(_ => _.DefinedTypes);
+        All = _assemblies.SelectMany(_ => _.DefinedTypes).ToArray();
         _contractToImplementorsMap.Feed(All);
     }
 


### PR DESCRIPTION
### Fixed

- Improve performance by explicitly doing `.ToArray()` on expensive LINQ queries for assembly and type discovery.
