### PR TITLE
Export Fields

### DIFF
--- a/Source/JavaScript/index.ts
+++ b/Source/JavaScript/index.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 export * from './Constructor';
+export * from './Fields';
 export * from './Guid';
 export * from './IEquatable';
 export * from './PropertyAccessor';

--- a/Source/JavaScript/package.json
+++ b/Source/JavaScript/package.json
@@ -35,7 +35,7 @@
         "up": "yarn g:up"
     },
     "dependencies": {
-        "@aksio/typescript": "1.0.5-test2",
+        "@aksio/typescript": "1.0.0",
         "reflect-metadata": "0.1.13"
     }
 }


### PR DESCRIPTION
### Fixed

- Export the `Fields` type in JS. Making it easier to access information about types.
