### PR TITLE
Export field

### DIFF
--- a/Source/JavaScript/index.ts
+++ b/Source/JavaScript/index.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 export * from './Constructor';
+export * from './Field';
 export * from './Fields';
 export * from './Guid';
 export * from './IEquatable';


### PR DESCRIPTION
### Fixed

- Export `Field` type in JavaScript fundamentals.
- Export `DerivedType` type in JavaScript fundamentals.
