### PR TITLE
Ignore project referenced assemblies

### DIFF
--- a/Source/DotNET/Fundamentals/Types/PackageReferencedAssemblies.cs
+++ b/Source/DotNET/Fundamentals/Types/PackageReferencedAssemblies.cs
@@ -51,7 +51,8 @@ public class PackageReferencedAssemblies : ICanProvideAssembliesForDiscovery
             var dependencyModel = DependencyContext.Load(entryAssembly);
 
             var assemblies = dependencyModel.RuntimeLibraries
-                                .Where(_ => _.RuntimeAssemblyGroups.Count > 0 &&
+                                .Where(_ => !_.Type.Equals("project") &&
+                                            _.RuntimeAssemblyGroups.Count > 0 &&
                                             _assemblyPrefixesToInclude.Any(asm => _.Name.StartsWith(asm)))
                                 .Select(_ => AssemblyHelpers.Resolve(_.Name)!)
                                 .Where(_ => _ is not null)


### PR DESCRIPTION
### Fixed

- Fixing so that the package assembly provider ignores the project referenced assemblies. This was that caused type duplication when used in combination with the `ProjectReferencedAssemblies` in a composition using for instance the `CompositeAssemblyProvider`.
