### PR TITLE
To camel case

### DIFF
--- a/Source/DotNET/Fundamentals/Json/Globals.cs
+++ b/Source/DotNET/Fundamentals/Json/Globals.cs
@@ -43,7 +43,7 @@ public static class Globals
 
         _jsonSerializerOptions = new()
         {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            PropertyNamingPolicy = AcronymFriendlyJsonCamelCaseNamingPolicy.Instance,
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
             Converters =
             {

--- a/Source/DotNET/Fundamentals/Serialization/AcronymFriendlyJsonCamelCaseNamingPolicy.cs
+++ b/Source/DotNET/Fundamentals/Serialization/AcronymFriendlyJsonCamelCaseNamingPolicy.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using Aksio.Strings;
+
+namespace Aksio.Serialization;
+
+public class AcronymFriendlyJsonCamelCaseNamingPolicy:  JsonNamingPolicy
+{
+    public static readonly JsonNamingPolicy Instance = new AcronymFriendlyJsonCamelCaseNamingPolicy();
+    /// <inheritdoc/>
+    public override string ConvertName(string name) => name.ToCamelCase();
+}

--- a/Source/DotNET/Fundamentals/Serialization/AcronymFriendlyJsonCamelCaseNamingPolicy.cs
+++ b/Source/DotNET/Fundamentals/Serialization/AcronymFriendlyJsonCamelCaseNamingPolicy.cs
@@ -6,9 +6,16 @@ using Aksio.Strings;
 
 namespace Aksio.Serialization;
 
-public class AcronymFriendlyJsonCamelCaseNamingPolicy:  JsonNamingPolicy
+/// <summary>
+/// A <see cref="JsonNamingPolicy"/> that converts names to camel case, but also takes acronyms into consideration.
+/// </summary>
+public class AcronymFriendlyJsonCamelCaseNamingPolicy : JsonNamingPolicy
 {
+    /// <summary>
+    /// A singleton instance of the <see cref="AcronymFriendlyJsonCamelCaseNamingPolicy"/>.
+    /// </summary>
     public static readonly JsonNamingPolicy Instance = new AcronymFriendlyJsonCamelCaseNamingPolicy();
+
     /// <inheritdoc/>
     public override string ConvertName(string name) => name.ToCamelCase();
 }

--- a/Source/DotNET/Fundamentals/Strings/StringExtensions.cs
+++ b/Source/DotNET/Fundamentals/Strings/StringExtensions.cs
@@ -9,71 +9,6 @@ namespace Aksio.Strings;
 public static class StringExtensions
 {
     /// <summary>
-    /// Convert a string into a camel cased string.
-    ///
-    /// If the string is empty or null or starts with a lower-case letter, the string is returned unchanged.
-    /// Also, if the string starts with two upper-case letters (suggesting an acronym), the string is returned unchanged.
-    ///
-    /// </summary>
-    /// <param name="stringToConvert">string to convert.</param>
-    /// <returns>Converted string.</returns>
-    public static string ToCamelCase(this string stringToConvert) =>
-        // This implementation is adapted from the JsonCamelCaseNamingPolicy implementation in System.Text.Json
-        // https://github.com/dotnet/runtime/blob/f6a96fb85f187cc749843ac1cc8186431498df18/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NamingPolicyUnitTests.cs
-#pragma warning disable CS8603 // Possible null reference return.
-        stringToConvert switch
-        {
-            null or "" => stringToConvert,
-            _ when stringToConvert.Length >= 2 && char.IsUpper(stringToConvert[0]) && char.IsUpper(stringToConvert[1]) => stringToConvert,
-            _ when !char.IsUpper(stringToConvert[0]) => stringToConvert,
-            _ => ConvertToCamelCase(stringToConvert),
-        };
-#pragma warning restore CS8603 // Possible null reference return.
-
-    static string ConvertToCamelCase(string stringToConvert)
-    {
-#if NETCOREAPP
-        return string.Create(stringToConvert.Length, stringToConvert, (chars, name) =>
-        {
-            name.CopyTo(chars);
-            FixCamelCasing(chars);
-        });
-#else
-    char[] chars = stringToConvert.ToCharArray();
-    FixCasing(chars);
-    return new string(chars);
-#endif
-    }
-
-    // from https://github.com/dotnet/runtime/blob/f6a96fb85f187cc749843ac1cc8186431498df18/src/libraries/System.Text.Json/Common/JsonCamelCaseNamingPolicy.cs
-    static void FixCamelCasing(Span<char> chars)
-    {
-        for (var i = 0; i < chars.Length; i++)
-        {
-            if (i == 1 && !char.IsUpper(chars[i]))
-            {
-                break;
-            }
-
-            var hasNext = (i + 1 < chars.Length);
-
-            // Stop when next char is already lowercase.
-            if (i > 0 && hasNext && !char.IsUpper(chars[i + 1]))
-            {
-                // If the next char is a space, lowercase current char before exiting.
-                if (chars[i + 1] == ' ')
-                {
-                    chars[i] = char.ToLowerInvariant(chars[i]);
-                }
-
-                break;
-            }
-
-            chars[i] = char.ToLowerInvariant(chars[i]);
-        }
-    }
-
-    /// <summary>
     /// Convert a string into a pascal cased string.
     /// </summary>
     /// <param name="stringToConvert">string to convert.</param>
@@ -90,5 +25,77 @@ public static class StringExtensions
         }
 
         return stringToConvert;
+    }
+
+    /// <summary>
+    /// <para>Convert a string into a camel cased string.</para>
+    /// <para>
+    /// If the string is empty or null or starts with a lower-case letter, the string is returned unchanged.
+    /// Also, if the string starts with two upper-case letters (suggesting an acronym), the string is returned unchanged.
+    /// </para>
+    ///
+    /// </summary>
+    /// <param name="stringToConvert">string to convert.</param>
+    /// <returns>Converted string.</returns>
+    public static string ToCamelCase(this string stringToConvert)
+    {
+        // This implementation is adapted from the JsonCamelCaseNamingPolicy implementation in System.Text.Json
+        // https://github.com/dotnet/runtime/blob/f6a96fb85f187cc749843ac1cc8186431498df18/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NamingPolicyUnitTests.cs
+#pragma warning disable CS8603 // Possible null reference return.
+        return stringToConvert switch
+        {
+            null or "" => stringToConvert,
+            _ when stringToConvert.Length >= 2 && char.IsUpper(stringToConvert[0]) &&
+                   char.IsUpper(stringToConvert[1]) => stringToConvert,
+            _ when !char.IsUpper(stringToConvert[0]) => stringToConvert,
+            _ => ConvertToCamelCase(stringToConvert),
+        };
+#pragma warning restore CS8603 // Possible null reference return.
+    }
+
+    static string ConvertToCamelCase(string stringToConvert)
+    {
+#if NETCOREAPP
+        return string.Create(stringToConvert.Length, stringToConvert, (chars, name) =>
+        {
+            name.CopyTo(chars);
+            FixCamelCasing(chars);
+        });
+#else
+    char[] chars = stringToConvert.ToCharArray();
+    FixCasing(chars);
+    return new string(chars);
+#endif
+    }
+
+    /// <summary>
+    /// from https://github.com/dotnet/runtime/blob/f6a96fb85f187cc749843ac1cc8186431498df18/src/libraries/System.Text.Json/Common/JsonCamelCaseNamingPolicy.cs.
+    /// </summary>
+    /// <param name="chars">Span of chars representing the string.</param>
+    static void FixCamelCasing(Span<char> chars)
+    {
+        for (var i = 0; i < chars.Length; i++)
+        {
+            if (i == 1 && !char.IsUpper(chars[i]))
+            {
+                break;
+            }
+
+            var hasNext = i + 1 < chars.Length;
+
+            // Stop when next char is already lowercase.
+            if (i > 0 && hasNext && !char.IsUpper(chars[i + 1]))
+            {
+                // If the next char is a space, lowercase current char before exiting.
+                if (chars[i + 1] == ' ')
+                {
+                    chars[i] = char.ToLowerInvariant(chars[i]);
+                }
+
+                break;
+            }
+
+            chars[i] = char.ToLowerInvariant(chars[i]);
+        }
     }
 }

--- a/Source/DotNET/Fundamentals/Strings/StringExtensions.cs
+++ b/Source/DotNET/Fundamentals/Strings/StringExtensions.cs
@@ -10,21 +10,67 @@ public static class StringExtensions
 {
     /// <summary>
     /// Convert a string into a camel cased string.
+    ///
+    /// If the string is empty or null or starts with a lower-case letter, the string is returned unchanged.
+    /// Also, if the string starts with two upper-case letters (suggesting an acronym), the string is returned unchanged.
+    ///
     /// </summary>
     /// <param name="stringToConvert">string to convert.</param>
     /// <returns>Converted string.</returns>
-    public static string ToCamelCase(this string stringToConvert)
-    {
-        if (!string.IsNullOrEmpty(stringToConvert))
+    public static string ToCamelCase(this string stringToConvert) =>
+        // This implementation is adapted from the JsonCamelCaseNamingPolicy implementation in System.Text.Json
+        // https://github.com/dotnet/runtime/blob/f6a96fb85f187cc749843ac1cc8186431498df18/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/NamingPolicyUnitTests.cs
+#pragma warning disable CS8603 // Possible null reference return.
+        stringToConvert switch
         {
-            if (stringToConvert.Length == 1)
-                return stringToConvert.ToLowerInvariant();
+            null or "" => stringToConvert,
+            _ when stringToConvert.Length >= 2 && char.IsUpper(stringToConvert[0]) && char.IsUpper(stringToConvert[1]) => stringToConvert,
+            _ when !char.IsUpper(stringToConvert[0]) => stringToConvert,
+            _ => ConvertToCamelCase(stringToConvert),
+        };
+#pragma warning restore CS8603 // Possible null reference return.
 
-            var firstLetter = stringToConvert[0].ToString().ToLowerInvariant();
-            return $"{firstLetter}{stringToConvert.Substring(1)}";
+    static string ConvertToCamelCase(string stringToConvert)
+    {
+#if NETCOREAPP
+        return string.Create(stringToConvert.Length, stringToConvert, (chars, name) =>
+        {
+            name.CopyTo(chars);
+            FixCamelCasing(chars);
+        });
+#else
+    char[] chars = stringToConvert.ToCharArray();
+    FixCasing(chars);
+    return new string(chars);
+#endif
+    }
+
+    // from https://github.com/dotnet/runtime/blob/f6a96fb85f187cc749843ac1cc8186431498df18/src/libraries/System.Text.Json/Common/JsonCamelCaseNamingPolicy.cs
+    static void FixCamelCasing(Span<char> chars)
+    {
+        for (var i = 0; i < chars.Length; i++)
+        {
+            if (i == 1 && !char.IsUpper(chars[i]))
+            {
+                break;
+            }
+
+            var hasNext = (i + 1 < chars.Length);
+
+            // Stop when next char is already lowercase.
+            if (i > 0 && hasNext && !char.IsUpper(chars[i + 1]))
+            {
+                // If the next char is a space, lowercase current char before exiting.
+                if (chars[i + 1] == ' ')
+                {
+                    chars[i] = char.ToLowerInvariant(chars[i]);
+                }
+
+                break;
+            }
+
+            chars[i] = char.ToLowerInvariant(chars[i]);
         }
-
-        return stringToConvert;
     }
 
     /// <summary>

--- a/Specifications/Fundamentals/Strings/for_ToCamelCase/when_converting.cs
+++ b/Specifications/Fundamentals/Strings/for_ToCamelCase/when_converting.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Aksio.Strings.for_ToCamelCase;
+
+public class when_converting
+{
+        [Theory]
+        // These test cases were copied from Json.NET via System.Text.Json in the DotNet framework.
+        [InlineData("URLValue", "URLValue")]
+        [InlineData("URL", "URL")]
+        [InlineData("ID", "ID")]
+        [InlineData("i", "I")]
+        [InlineData("", "")]
+        [InlineData("😀葛🀄", "😀葛🀄")] // Surrogate pairs
+        [InlineData("άλφαΒήταΓάμμα", "ΆλφαΒήταΓάμμα")] // Non-ascii letters
+        [InlineData("𐐀𐐨𐐨𐐀𐐨𐐨", "𐐀𐐨𐐨𐐀𐐨𐐨")] // Surrogate pair letters don't normalize
+        [InlineData("\ude00\ud83d", "\ude00\ud83d")] // Unpaired surrogates
+        [InlineData("person", "Person")]
+        [InlineData("iPhone", "iPhone")]
+        [InlineData("IPhone", "IPhone")]
+        [InlineData("i Phone", "I Phone")]
+        [InlineData("i  Phone", "I  Phone")]
+        [InlineData(" IPhone", " IPhone")]
+        [InlineData(" IPhone ", " IPhone ")]
+        [InlineData("isCIA", "IsCIA")]
+        [InlineData("vmQ", "VmQ")]
+        [InlineData("xml2Json", "Xml2Json")]
+        [InlineData("snAkEcAsE", "SnAkEcAsE")]
+        [InlineData("snA__kEcAsE", "SnA__kEcAsE")]
+        [InlineData("snA__ kEcAsE", "SnA__ kEcAsE")]
+        [InlineData("already_snake_case_ ", "already_snake_case_ ")]
+        [InlineData("isJSONProperty", "IsJSONProperty")]
+        [InlineData("SHOUTING_CASE", "SHOUTING_CASE")]
+        [InlineData("9999-12-31T23:59:59.9999999Z", "9999-12-31T23:59:59.9999999Z")]
+        [InlineData("hi!! This is text. Time to test.", "Hi!! This is text. Time to test.")]
+        [InlineData("BUILDING", "BUILDING")]
+        [InlineData("BUILDING Property", "BUILDING Property")]
+        [InlineData("building Property", "Building Property")]
+        [InlineData("BUILDING PROPERTY", "BUILDING PROPERTY")]
+        public static void ToCamelCaseTest(string expectedResult, string name)
+        {
+            var converted = name.ToCamelCase();
+            Assert.Equal(expectedResult, converted);
+        }
+
+        [Fact]
+        public static void CamelCaseNullNameReturnsNull()
+        {
+            string name = null;
+            Assert.Null(name.ToCamelCase());
+        }
+}

--- a/Specifications/Fundamentals/Strings/for_ToCamelCase/when_converting.cs
+++ b/Specifications/Fundamentals/Strings/for_ToCamelCase/when_converting.cs
@@ -3,51 +3,53 @@
 
 namespace Aksio.Strings.for_ToCamelCase;
 
-public class when_converting
+public static class when_converting
 {
-        [Theory]
-        // These test cases were copied from Json.NET via System.Text.Json in the DotNet framework.
-        [InlineData("URLValue", "URLValue")]
-        [InlineData("URL", "URL")]
-        [InlineData("ID", "ID")]
-        [InlineData("i", "I")]
-        [InlineData("", "")]
-        [InlineData("😀葛🀄", "😀葛🀄")] // Surrogate pairs
-        [InlineData("άλφαΒήταΓάμμα", "ΆλφαΒήταΓάμμα")] // Non-ascii letters
-        [InlineData("𐐀𐐨𐐨𐐀𐐨𐐨", "𐐀𐐨𐐨𐐀𐐨𐐨")] // Surrogate pair letters don't normalize
-        [InlineData("\ude00\ud83d", "\ude00\ud83d")] // Unpaired surrogates
-        [InlineData("person", "Person")]
-        [InlineData("iPhone", "iPhone")]
-        [InlineData("IPhone", "IPhone")]
-        [InlineData("i Phone", "I Phone")]
-        [InlineData("i  Phone", "I  Phone")]
-        [InlineData(" IPhone", " IPhone")]
-        [InlineData(" IPhone ", " IPhone ")]
-        [InlineData("isCIA", "IsCIA")]
-        [InlineData("vmQ", "VmQ")]
-        [InlineData("xml2Json", "Xml2Json")]
-        [InlineData("snAkEcAsE", "SnAkEcAsE")]
-        [InlineData("snA__kEcAsE", "SnA__kEcAsE")]
-        [InlineData("snA__ kEcAsE", "SnA__ kEcAsE")]
-        [InlineData("already_snake_case_ ", "already_snake_case_ ")]
-        [InlineData("isJSONProperty", "IsJSONProperty")]
-        [InlineData("SHOUTING_CASE", "SHOUTING_CASE")]
-        [InlineData("9999-12-31T23:59:59.9999999Z", "9999-12-31T23:59:59.9999999Z")]
-        [InlineData("hi!! This is text. Time to test.", "Hi!! This is text. Time to test.")]
-        [InlineData("BUILDING", "BUILDING")]
-        [InlineData("BUILDING Property", "BUILDING Property")]
-        [InlineData("building Property", "Building Property")]
-        [InlineData("BUILDING PROPERTY", "BUILDING PROPERTY")]
-        public static void ToCamelCaseTest(string expectedResult, string name)
-        {
-            var converted = name.ToCamelCase();
-            Assert.Equal(expectedResult, converted);
-        }
+#pragma warning disable RCS1181
+    // These test cases were copied from Json.NET via System.Text.Json in the DotNet framework.
+#pragma warning restore RCS1181
+    [Theory]
+    [InlineData("URLValue", "URLValue")]
+    [InlineData("URL", "URL")]
+    [InlineData("ID", "ID")]
+    [InlineData("i", "I")]
+    [InlineData("", "")]
+    [InlineData("😀葛🀄", "😀葛🀄")] // Surrogate pairs
+    [InlineData("άλφαΒήταΓάμμα", "ΆλφαΒήταΓάμμα")] // Non-ascii letters
+    [InlineData("𐐀𐐨𐐨𐐀𐐨𐐨", "𐐀𐐨𐐨𐐀𐐨𐐨")] // Surrogate pair letters don't normalize
+    [InlineData("\ude00\ud83d", "\ude00\ud83d")] // Unpaired surrogates
+    [InlineData("person", "Person")]
+    [InlineData("iPhone", "iPhone")]
+    [InlineData("IPhone", "IPhone")]
+    [InlineData("i Phone", "I Phone")]
+    [InlineData("i  Phone", "I  Phone")]
+    [InlineData(" IPhone", " IPhone")]
+    [InlineData(" IPhone ", " IPhone ")]
+    [InlineData("isCIA", "IsCIA")]
+    [InlineData("vmQ", "VmQ")]
+    [InlineData("xml2Json", "Xml2Json")]
+    [InlineData("snAkEcAsE", "SnAkEcAsE")]
+    [InlineData("snA__kEcAsE", "SnA__kEcAsE")]
+    [InlineData("snA__ kEcAsE", "SnA__ kEcAsE")]
+    [InlineData("already_snake_case_ ", "already_snake_case_ ")]
+    [InlineData("isJSONProperty", "IsJSONProperty")]
+    [InlineData("SHOUTING_CASE", "SHOUTING_CASE")]
+    [InlineData("9999-12-31T23:59:59.9999999Z", "9999-12-31T23:59:59.9999999Z")]
+    [InlineData("hi!! This is text. Time to test.", "Hi!! This is text. Time to test.")]
+    [InlineData("BUILDING", "BUILDING")]
+    [InlineData("BUILDING Property", "BUILDING Property")]
+    [InlineData("building Property", "Building Property")]
+    [InlineData("BUILDING PROPERTY", "BUILDING PROPERTY")]
+    public static void ToCamelCaseTest(string expectedResult, string name)
+    {
+        var converted = name.ToCamelCase();
+        Assert.Equal(expectedResult, converted);
+    }
 
-        [Fact]
-        public static void CamelCaseNullNameReturnsNull()
-        {
-            string name = null;
-            Assert.Null(name.ToCamelCase());
-        }
+    [Fact]
+    public static void CamelCaseNullNameReturnsNull()
+    {
+        string name = null;
+        Assert.Null(name.ToCamelCase());
+    }
 }


### PR DESCRIPTION
## Summary

Create a ToCamelCase implementation that is more friendly towards acronyms.  This is a trade-off between determining it is an acronym and ease of use / performance.  There is no register or dictionary of acronyms, instead if the first two characters of the name are upper-case we will not change the name and will just return as is.

A JsonNamingPolicy implementation is created that uses the ToCamelCase extension method.